### PR TITLE
cmake: Python modules must link against python library

### DIFF
--- a/src/interfaces/python/opengm/hdf5/CMakeLists.txt
+++ b/src/interfaces/python/opengm/hdf5/CMakeLists.txt
@@ -54,7 +54,7 @@ endif(APPLE)
 if(MSVC AND NOT(MSVC_VERSION LESS 1400))
     SET_TARGET_PROPERTIES(_hdf5 PROPERTIES COMPILE_FLAGS "/bigobj")
 endif()
-target_link_libraries(_hdf5 ${Boost_PYTHON_LIBRARIES}  ${HDF5_LIBRARIES})
+target_link_libraries(_hdf5 ${PYTHON_LIBRARIES} ${Boost_PYTHON_LIBRARIES}  ${HDF5_LIBRARIES})
 set_target_properties(_hdf5 PROPERTIES PREFIX "")
 
 

--- a/src/interfaces/python/opengm/inference/CMakeLists.txt
+++ b/src/interfaces/python/opengm/inference/CMakeLists.txt
@@ -80,9 +80,9 @@ endif()
 
 if(LINK_RT)
     find_library(RT rt)
-    target_link_libraries(_inference ${Boost_PYTHON_LIBRARIES} rt)
+    target_link_libraries(_inference ${PYTHON_LIBRARIES} ${Boost_PYTHON_LIBRARIES} rt)
 else()
-    target_link_libraries(_inference ${Boost_PYTHON_LIBRARIES})
+    target_link_libraries(_inference ${PYTHON_LIBRARIES} ${Boost_PYTHON_LIBRARIES})
 endif(LINK_RT)
 
 set_target_properties(_inference PROPERTIES PREFIX "")

--- a/src/interfaces/python/opengm/opengmcore/CMakeLists.txt
+++ b/src/interfaces/python/opengm/opengmcore/CMakeLists.txt
@@ -79,9 +79,9 @@ endif()
 
 if(LINK_RT)
     find_library(RT rt)
-    target_link_libraries(_opengmcore ${Boost_PYTHON_LIBRARIES} rt)
+    target_link_libraries(_opengmcore ${PYTHON_LIBRARIES} ${Boost_PYTHON_LIBRARIES} rt)
 else()
-    target_link_libraries(_opengmcore ${Boost_PYTHON_LIBRARIES})
+    target_link_libraries(_opengmcore ${PYTHON_LIBRARIES} ${Boost_PYTHON_LIBRARIES})
 endif(LINK_RT)
 
 IF(WITH_MAXFLOW)


### PR DESCRIPTION
These little changes were necessary to get your master branch building on Mac.